### PR TITLE
Add TutorialSearch to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Curated list of blog posts, videos and resources on testing blockchains and Web3
 * [Learn Blockchain, Solidity, and Full Stack Web3 Development with JavaScript – 32-Hour Course](https://youtu.be/gyMwXuJrbJQ?si=Uini5LuPalQmaSbd) - free 32-hour course on smart contract development with Javascript / Solidity
 * [Blockchain Specialization](https://www.coursera.org/specializations/blockchain)
 * [Decentralized Finance (DeFi): The Future of Finance Specialization](https://www.coursera.org/specializations/decentralized-finance-duke)
-* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+* [TutorialSearch](https://tutorialsearch.io/browse/blockchain-web3/blockchain-applications) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ### Videos
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Curated list of blog posts, videos and resources on testing blockchains and Web3
 * [Learn Blockchain, Solidity, and Full Stack Web3 Development with JavaScript – 32-Hour Course](https://youtu.be/gyMwXuJrbJQ?si=Uini5LuPalQmaSbd) - free 32-hour course on smart contract development with Javascript / Solidity
 * [Blockchain Specialization](https://www.coursera.org/specializations/blockchain)
 * [Decentralized Finance (DeFi): The Future of Finance Specialization](https://www.coursera.org/specializations/decentralized-finance-duke)
+* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 ### Videos
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Courses* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/blockchain-web3/blockchain-applications) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/blockchain-web3/blockchain-applications) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.